### PR TITLE
Additional columns

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ end
 
 <br/>
 
-#### Metadata (Example: multiple fields)
+#### Multiple Fields
 
 To allow finding employees by multiple traits (e.g by name, job title, or short biography), you can define multiple `insert` statements per employee:
 
@@ -86,20 +86,9 @@ Hayfork.maintain(Haystack) do
 end
 ```
 
-:point_right: The `UPDATE` logic assumes that each row in the haystack can be uniquely identified by static attributes (e.g. `search_result_id`, `search_result_type`). If we update just `employees.position`, we need to give Hayfork a way of differentiating the record for `position` from the records for `full_name` and `short_bio`. We'll do that by adding a new column (`field`) to the haystack table and giving it a different static value for each row:
-
-```ruby
-Hayfork.maintain(Haystack) do
-  foreach(Employee) do
-    insert(:full_name).merge(field: "full_name")
-    insert(:position).merge(field: "position")
-    insert(:short_bio).merge(field: "short_bio")
-  end
-end
-```
 <br/>
 
-#### Metadata (Example: scoped searches)
+#### Scoping Searches
 
 Additional columns on `haystack` can also be useful for scoping searches. Suppose we're maintaining a database of employees for multiple companies. We would want to scope searches by company. If we've added `company_id` to our haystack, we can populate it like this:
 
@@ -108,9 +97,9 @@ Hayfork.maintain(Haystack) do
   foreach(Employee) do
     set :company_id, row[:company_id]
 
-    insert(:full_name).merge(field: "full_name")
-    insert(:position).merge(field: "position")
-    insert(:short_bio).merge(field: "short_bio")
+    insert(:full_name)
+    insert(:position)
+    insert(:short_bio)
   end
 end
 ```
@@ -121,8 +110,9 @@ In this line,
     set :company_id, row[:company_id]
 ```
 
-1. `row` is an `Arel::Table` that represents the row passed to the trigger; `row` is present in every block.
-2. `set` works similarly to `merge`: `set` assigns a value that will be inserted in the haystack for all following `insert` statements while `.merge` applies only to the `insert` statement that it is chained onto.
+1. `row` is an instance of `Arel::Table` that represents the row passed to the trigger; `row` is present in every `foreach` block.
+2. `set` assigns a value that will be inserted in the haystack for all following `insert` statements.
+
 <br/>
 
 #### belongs_to
@@ -179,21 +169,6 @@ Hayfork.maintain(Haystack) do
 end
 ```
 
-:point_right: The `UPDATE` logic assumes that each row in the haystack can be uniquely identified by static attributes (e.g. `search_result_id`, `search_result_type`). If we update the text of _one_ of an article's comments, we need to give Hayfork a way of differentiating the entries that may be replaced from the ones that shouldn't change. We'll do that by adding a new column (`ref_id`) to the haystack table and giving it a value that identifies the comment that corresponds to the entry:
-
-```ruby
-Hayfork.maintain(Haystack) do
-  foreach(Article) do
-    insert(comments: :text)
-  end
-  foreach(Comment.joins(:article)) do
-    set :search_result_type, "Article"
-    set :search_result_id, Article.arel_table[:id]
-
-    insert(:text).merge(ref_id: row[:id])
-  end
-end
-```
 <br/>
 
 #### Rebuild Triggers

--- a/lib/generators/hayfork/templates/migrations/create.rb
+++ b/lib/generators/hayfork/templates/migrations/create.rb
@@ -20,7 +20,7 @@ class Create<%= table_name.camelize %> < ActiveRecord::Migration<%= migration_ve
       ALTER TEXT SEARCH CONFIGURATION public.hayfork ALTER MAPPING FOR asciiword, asciihword, hword_asciipart, hword, hword_part, word WITH unaccent, english_stem;
     SQL
 
-    create_table :<%= table_name %> do |t|
+    create_table :<%= table_name %>, id: false do |t|
       t.string :<%= Hayfork::SEARCH_RESULT_TYPE %>, null: false
       t.integer :<%= Hayfork::SEARCH_RESULT_ID %>, null: false
       t.tsvector :<%= Hayfork::SEARCH_VECTOR %>
@@ -41,8 +41,6 @@ class Create<%= table_name.camelize %> < ActiveRecord::Migration<%= migration_ve
       #
       #    t.integer :ref_id
       #
-
-      t.timestamps null: false, default: -> { "NOW()" }
 
       # If you add columns that will always be used in searches (like `user_id`),
       # consider including them in this index. For example:

--- a/lib/generators/hayfork/templates/migrations/create.rb
+++ b/lib/generators/hayfork/templates/migrations/create.rb
@@ -24,7 +24,7 @@ class Create<%= table_name.camelize %> < ActiveRecord::Migration<%= migration_ve
       t.string :<%= Hayfork::SEARCH_RESULT_TYPE %>, null: false
       t.integer :<%= Hayfork::SEARCH_RESULT_ID %>, null: false
       t.tsvector :<%= Hayfork::SEARCH_VECTOR %>
-      t.text :<%= Hayfork::TEXT %>
+      t.text :<%= Hayfork::TEXT %>, null: false
 
       # Add additional columns to <%= table_name %> here.
       #

--- a/lib/generators/hayfork/templates/migrations/create.rb
+++ b/lib/generators/hayfork/templates/migrations/create.rb
@@ -23,6 +23,11 @@ class Create<%= table_name.camelize %> < ActiveRecord::Migration<%= migration_ve
     create_table :<%= table_name %>, id: false do |t|
       t.string :<%= Hayfork::SEARCH_RESULT_TYPE %>, null: false
       t.integer :<%= Hayfork::SEARCH_RESULT_ID %>, null: false
+
+      t.string :<%= Hayfork::SOURCE_TYPE %>, null: false
+      t.integer :<%= Hayfork::SOURCE_ID %>, null: false
+      t.string :<%= Hayfork::FIELD %>, null: false
+
       t.tsvector :<%= Hayfork::SEARCH_VECTOR %>
       t.text :<%= Hayfork::TEXT %>, null: false
 
@@ -32,14 +37,6 @@ class Create<%= table_name.camelize %> < ActiveRecord::Migration<%= migration_ve
       # own creation:
       #
       #    t.belongs_to :user, null: false
-      #
-      # or to allow users to constrain a search by a particular field:
-      #
-      #    t.string :field, null: false
-      #
-      # or to allow finding a result by the of content of its subrecords:
-      #
-      #    t.integer :ref_id
       #
 
       # If you add columns that will always be used in searches (like `user_id`),

--- a/lib/hayfork.rb
+++ b/lib/hayfork.rb
@@ -14,6 +14,9 @@ module Hayfork
   SEARCH_VECTOR = "search_vector".freeze
   SEARCH_RESULT_TYPE = "search_result_type".freeze
   SEARCH_RESULT_ID = "search_result_id".freeze
+  SOURCE_TYPE = "source_type".freeze
+  SOURCE_ID = "source_id".freeze
+  FIELD = "field".freeze
 
   @default_weight = "C".freeze
   @default_dictionary = "hayfork".freeze

--- a/lib/hayfork/statement.rb
+++ b/lib/hayfork/statement.rb
@@ -46,7 +46,11 @@ module Hayfork
     end
 
     def merge(attrs = {})
-      attributes.merge! attrs.stringify_keys.except(Hayfork::SEARCH_VECTOR, Hayfork::TEXT)
+      attributes.merge! attrs.stringify_keys.except(
+        Hayfork::SEARCH_VECTOR,
+        Hayfork::TEXT,
+        Hayfork::SOURCE_TYPE,
+        Hayfork::SOURCE_ID)
       self
     end
 
@@ -99,6 +103,9 @@ module Hayfork
           when Hayfork::SEARCH_RESULT_TYPE then model.name
           when Hayfork::SEARCH_RESULT_ID then model.arel_table["id"]
           when Hayfork::SEARCH_VECTOR, Hayfork::TEXT then self.value
+          when Hayfork::SOURCE_TYPE then self.value.relation.send(:type_caster).send(:types).name
+          when Hayfork::SOURCE_ID then self.value.relation["id"]
+          when Hayfork::FIELD then self.value.name
           end
         end
 

--- a/lib/hayfork/statement.rb
+++ b/lib/hayfork/statement.rb
@@ -92,7 +92,6 @@ module Hayfork
 
     def bindings
       @bindings ||= (haystack.columns.each_with_object([]) do |column, bindings|
-        next if IGNORED_COLUMNS.member?(column.name)
         next if column.name == Hayfork::SEARCH_VECTOR && unsearchable?
 
         value = attributes.fetch column.name do
@@ -121,12 +120,6 @@ module Hayfork
     def reflection_for(association)
       Hayfork.reflection_for(model, association)
     end
-
-    IGNORED_COLUMNS = %w{
-      id
-      created_at
-      updated_at
-    }.freeze
 
   end
 end

--- a/test/integration/haystack_test.rb
+++ b/test/integration/haystack_test.rb
@@ -11,11 +11,12 @@ class HaystackTest < Minitest::Test
   end
 
 
-  context "If we're maintaining just books' titles in the haystack" do
+  context "If we're maintaining books in the haystack" do
     setup do
       triggers do
         foreach Book do |index|
           index.insert(:title)
+          index.insert(:description)
         end
       end
     end
@@ -24,7 +25,7 @@ class HaystackTest < Minitest::Test
       should "create an entry in the haystack" do
         book = Book.create!(title: "The Chosen")
 
-        assert_equal [[book.id, "The Chosen"]], Haystack.pluck(:search_result_id, :text)
+        assert_equal [[book.id, "title", "The Chosen"]], Haystack.pluck(:search_result_id, :field, :text)
       end
     end
 
@@ -41,18 +42,19 @@ class HaystackTest < Minitest::Test
     context "Renaming a book" do
       should "replace [only] its entry in the haystack" do
         book1 = Book.create!(title: "The Chosen")
-        book2 = Book.create!(title: "My Name is Asher Lev")
+        book2 = Book.create!(title: "My Name is Asher Lev", description: "Asher Lev is a Ladover Hasid who keeps kosher...")
         book2.update_column :title, "The Gift of Asher Lev"
 
-        assert_equal [
-          [book1.id, "The Chosen"],
-          [book2.id, "The Gift of Asher Lev"],
-        ], Haystack.pluck(:search_result_id, :text)
+        assert_equal Set[
+          [book1.id, "title", "The Chosen"],
+          [book2.id, "description", "Asher Lev is a Ladover Hasid who keeps kosher..."],
+          [book2.id, "title", "The Gift of Asher Lev"],
+        ], Haystack.pluck(:search_result_id, :field, :text).to_set
       end
     end
 
     context "Changing a book's ISBN" do
-      should "do nothing to the haystack" do
+      should "do nothing to the haystack if the ISBN isn't used" do
         book = Book.create!(title: "The Chosen", isbn: "0449213447")
 
         before = Haystack.pluck(:id)
@@ -61,6 +63,85 @@ class HaystackTest < Minitest::Test
       end
     end
   end
+
+
+  context "If we're maintaining a belongs_to relationship" do
+    setup do
+      triggers do
+        foreach(Book) do
+          insert(author: :name)
+        end
+        foreach(Author) do
+          joins :books
+          set :search_result_type, "Book"
+          set :search_result_id, Book.arel_table[:id]
+
+          insert(:name)
+        end
+      end
+    end
+
+    context "Updating an author" do
+      setup do
+        @author = Author.create!(name: "Chiam Potok")
+        @book1 = Book.create!(title: "The Chosen", author: @author)
+        @book2 = Book.create!(title: "My Name is Asher Lev", author: @author)
+      end
+
+      should "replace entries for _all_ the author's books" do
+        @author.update_column :name, "Chaim Potok"
+
+        assert_equal Set[
+          [@book1.id, "name", "Chaim Potok"],
+          [@book2.id, "name", "Chaim Potok"],
+        ], Haystack.pluck(:search_result_id, :field, :text).to_set
+      end
+
+      should "not touch entries for other authors" do
+        @book3 = Book.create!(title: "The Graveyard Book", author: Author.create!(name: "Neil Gaiman"))
+
+        before = Haystack.where(search_result_id: @book3.id).pluck(:id)
+        @author.update_column :name, "Chaim Potok"
+        assert_equal before, Haystack.where(search_result_id: @book3.id).pluck(:id)
+      end
+    end
+  end
+
+
+  context "If we're maintaining a has_many relationship" do
+    setup do
+      triggers do
+        foreach(Author) do
+          insert(:name)
+        end
+        foreach(Book.joins(:author)) do
+          set :search_result_type, "Author"
+          set :search_result_id, Author.arel_table[:id]
+
+          insert(:title)
+        end
+      end
+    end
+
+    context "Updating a book's title" do
+      setup do
+        @author = Author.create!(name: "Chiam Potok")
+        @book1 = Book.create!(title: "The Chosen", author: @author)
+        @book2 = Book.create!(title: "My Name is Asher Lev", author: @author)
+      end
+
+      should "replace [only] the entry for that book" do
+        @book2.update_column :title, "The Gift of Asher Lev"
+
+        assert_equal Set[
+          [@author.id, "name", "Chiam Potok"],
+          [@author.id, "title", "The Chosen"],
+          [@author.id, "title", "The Gift of Asher Lev"],
+        ], Haystack.pluck(:search_result_id, :field, :text).to_set
+      end
+    end
+  end
+
 
 private
 

--- a/test/support/db/schema.rb
+++ b/test/support/db/schema.rb
@@ -6,8 +6,6 @@ ActiveRecord::Schema.define(version: 1) do
     t.text     "text"
     t.tsvector "search_vector"
     t.string   "another_field"
-    t.datetime "created_at", null: false, default: -> { "NOW()" }
-    t.datetime "updated_at", null: false, default: -> { "NOW()" }
   end
 
   create_table "books", force: true do |t|

--- a/test/support/db/schema.rb
+++ b/test/support/db/schema.rb
@@ -3,6 +3,9 @@ ActiveRecord::Schema.define(version: 1) do
   create_table "haystack", force: true do |t|
     t.string   "search_result_type", null: false
     t.integer  "search_result_id", null: false
+    t.string   "source_type", null: false
+    t.integer  "source_id", null: false
+    t.string   "field", null: false
     t.text     "text", null: false
     t.tsvector "search_vector"
     t.string   "another_field"
@@ -12,7 +15,7 @@ ActiveRecord::Schema.define(version: 1) do
     t.integer  "author_id", null: true
     t.string   "title", null: false
     t.string   "isbn", null: true
-    t.text     "text", null: true
+    t.text     "description", null: true
   end
 
   create_table "authors", force: true do |t|

--- a/test/support/db/schema.rb
+++ b/test/support/db/schema.rb
@@ -3,7 +3,7 @@ ActiveRecord::Schema.define(version: 1) do
   create_table "haystack", force: true do |t|
     t.string   "search_result_type", null: false
     t.integer  "search_result_id", null: false
-    t.text     "text"
+    t.text     "text", null: false
     t.tsvector "search_vector"
     t.string   "another_field"
   end

--- a/test/unit/statement_test.rb
+++ b/test/unit/statement_test.rb
@@ -26,6 +26,18 @@ class StatementTest < Minitest::Test
       should "bind 'text' to the field passed to the statement" do
         assert_equal Book.arel_table["title"], bound_value_of(statement, Hayfork::TEXT)
       end
+
+      should "bind 'field' to the name of the field passed to the statement" do
+        assert_equal "title", bound_value_of(statement, Hayfork::FIELD)
+      end
+
+      should "bind 'source_type' to the name of the model passed to the statement" do
+        assert_equal "Book", bound_value_of(statement, Hayfork::SOURCE_TYPE)
+      end
+
+      should "bind 'source_id' to the id of the model passed to the statement" do
+        assert_equal Book.arel_table["id"], bound_value_of(statement, Hayfork::SOURCE_ID)
+      end
     end
 
 
@@ -38,13 +50,27 @@ class StatementTest < Minitest::Test
         assert_equal 1, bound_value_of(statement.merge(Hayfork::SEARCH_RESULT_ID => 1), Hayfork::SEARCH_RESULT_ID)
       end
 
+      should "allow overriding the binding of 'field'" do
+        assert_equal "grassy", bound_value_of(statement.merge(Hayfork::FIELD => "grassy"), Hayfork::FIELD)
+      end
+
+
       should "prohibit overriding the binding of 'search_vector'" do
-        assert_equal Book.arel_table["title"], bound_value_of(statement.merge(Hayfork::SEARCH_VECTOR => "NOPE"), Hayfork::SEARCH_VECTOR)
+        refute_equal "NOPE", bound_value_of(statement.merge(Hayfork::SEARCH_VECTOR => "NOPE"), Hayfork::SEARCH_VECTOR)
       end
 
       should "prohibit overriding the binding of 'text'" do
-        assert_equal Book.arel_table["title"], bound_value_of(statement.merge(Hayfork::TEXT => "NOPE"), Hayfork::TEXT)
+        refute_equal "NOPE", bound_value_of(statement.merge(Hayfork::TEXT => "NOPE"), Hayfork::TEXT)
       end
+
+      should "prohibit overriding the binding of 'source_type'" do
+        refute_equal "NOPE", bound_value_of(statement.merge(Hayfork::SOURCE_TYPE => "NOPE"), Hayfork::SOURCE_TYPE)
+      end
+
+      should "prohibit overriding the binding of 'source_id'" do
+        refute_equal 0, bound_value_of(statement.merge(Hayfork::SOURCE_ID => 0), Hayfork::SOURCE_ID)
+      end
+
 
       should "include bindings for arbitrary attributes that exist on Haystack" do
         assert_includes statement.merge(another_field: "example").bindings.map(&:key), "another_field"


### PR DESCRIPTION
related to #1

Removes unnecessary columns from the Haystack (`id`, `created_at`, `updated_at`) and adds columns to keep track of where a Haystack value came from (`source_type`, `source_id`, `field`). The latter simplifies the README and fully encapsulates the UPDATE logic in Hayfork.