### PR TITLE
Updated triggers filename to match the one created by HaystackGenerator

### DIFF
--- a/lib/generators/hayfork/templates/migrations/rebuild.rb
+++ b/lib/generators/hayfork/templates/migrations/rebuild.rb
@@ -1,4 +1,4 @@
-require "triggers"
+require "<%= file_name %>_triggers"
 
 class Rebuild<%= table_name.camelize %> < ActiveRecord::Migration<%= migration_version %>
   def up

--- a/test/integration/rebuild_generator_test.rb
+++ b/test/integration/rebuild_generator_test.rb
@@ -16,6 +16,7 @@ class RebuildGeneratorTest < Rails::Generators::TestCase
 
     should "generate a migration to rebuild the Haystack" do
       assert_migration "db/migrate/rebuild_haystack.rb" do |file|
+        assert_match /^require \"haystack_triggers\"/, file
         assert_match /^class RebuildHaystack < ActiveRecord::Migration/, file
         assert_match /execute Haystack.triggers/, file
       end
@@ -46,6 +47,7 @@ class RebuildGeneratorTest < Rails::Generators::TestCase
 
     should "generate a migration to rebuild the Haystack" do
       assert_migration "db/migrate/rebuild_monsters.rb" do |file|
+        assert_match /^require \"monster_triggers\"/, file
         assert_match /^class RebuildMonsters < ActiveRecord::Migration/, file
         assert_match /execute Monster.triggers/, file
       end


### PR DESCRIPTION
I think this was an oversight. The filename in the rebuild migration generator (`triggers.rb`) did not match the filename generated in `haystack_generator.rb` ([link](https://github.com/boblail/hayfork/blob/master/lib/generators/hayfork/haystack_generator.rb#L23)).