### PR TITLE
Rebuild migration template fix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,4 +13,6 @@ addons:
 services:
   - postgresql
 
-before_install: gem install bundler -v 1.16.1
+before_install:
+  - gem uninstall -v '>= 2' -i $(rvm gemdir)@global -ax bundler || true
+  - gem install bundler -v 1.16.1

--- a/lib/generators/hayfork/templates/migrations/rebuild.rb
+++ b/lib/generators/hayfork/templates/migrations/rebuild.rb
@@ -1,4 +1,4 @@
-require "triggers"
+require "<%= file_name %>_triggers"
 
 class Rebuild<%= table_name.camelize %> < ActiveRecord::Migration<%= migration_version %>
   def up

--- a/lib/generators/hayfork/templates/migrations/rebuild.rb
+++ b/lib/generators/hayfork/templates/migrations/rebuild.rb
@@ -3,6 +3,6 @@ require "<%= file_name %>_triggers"
 class Rebuild<%= table_name.camelize %> < ActiveRecord::Migration<%= migration_version %>
   def up
     execute <%= class_name %>.triggers.replace
-    execute <%= class_name %>.triggers.rebuild.lines
+    execute <%= class_name %>.triggers.rebuild
   end
 end

--- a/test/integration/rebuild_generator_test.rb
+++ b/test/integration/rebuild_generator_test.rb
@@ -16,6 +16,7 @@ class RebuildGeneratorTest < Rails::Generators::TestCase
 
     should "generate a migration to rebuild the Haystack" do
       assert_migration "db/migrate/rebuild_haystack.rb" do |file|
+        assert_match /^require \"haystack_triggers\"/, file
         assert_match /^class RebuildHaystack < ActiveRecord::Migration/, file
         assert_match /execute Haystack.triggers/, file
       end
@@ -46,6 +47,7 @@ class RebuildGeneratorTest < Rails::Generators::TestCase
 
     should "generate a migration to rebuild the Haystack" do
       assert_migration "db/migrate/rebuild_monsters.rb" do |file|
+        assert_match /^require \"monster_triggers\"/, file
         assert_match /^class RebuildMonsters < ActiveRecord::Migration/, file
         assert_match /execute Monster.triggers/, file
       end


### PR DESCRIPTION
This PR fixes a few issues with the rebuild migration generator. 

Without these fixes: 

1. The generator creates a file named `triggers.rb` rather than the expected `<file_name>_triggers.rb` (`file_name` is the variable used in the Haystack generator [here](https://github.com/boblail/hayfork/blob/master/lib/generators/hayfork/haystack_generator.rb#L23)).
2. The migration causes an exception when it sends an array to the execute method.
