### PR TITLE
Support Rails 6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,5 +14,5 @@ services:
   - postgresql
 
 before_install:
-  - gem uninstall -v '>= 2' -i $(rvm gemdir)@global -ax bundler || true
-  - gem install bundler -v 1.16.1
+    - gem update --system
+    - gem install bundler

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,7 @@
+## v1.1.0 (2019 Sept 24)
+
+* Support for Rails 6
+
+##  v1.0.0 (2019 Jan 2)
+
+* Initial release

--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,6 @@ git_source(:github) {|repo_name| "https://github.com/#{repo_name}" }
 # Specify your gem's dependencies in hayfork.gemspec
 gemspec
 
-gem "rails", "~> 5.2"
+gem "rails", ">= 5.2"
 
 gem "pry"

--- a/hayfork.gemspec
+++ b/hayfork.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "railties", ">= 5.2.0", "< 6.0"
 
-  spec.add_development_dependency "bundler", "~> 1.16"
+  spec.add_development_dependency "bundler", "~> 2.0.2"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "minitest", "~> 5.0"
   spec.add_development_dependency "minitest-reporters"

--- a/hayfork.gemspec
+++ b/hayfork.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.add_dependency "railties", ">= 5.2.0", "< 6.0"
+  spec.add_dependency "railties", ">= 5.2.0", "< 6.1"
 
   spec.add_development_dependency "bundler", "~> 2.0.2"
   spec.add_development_dependency "rake", "~> 10.0"

--- a/lib/hayfork/version.rb
+++ b/lib/hayfork/version.rb
@@ -1,3 +1,3 @@
 module Hayfork
-  VERSION = "1.0.0"
+  VERSION = "1.1.0"
 end


### PR DESCRIPTION
After looking at the overview of changes in Rails, it doesn't seem like there were any changes going from 5.2 to 6.0 that would cause troubles for the gem and its operations.

I did go ahead and also bump the version of `bundler`, updating `travis.yml` accordingly. Hopefully this is alright? In any case, I went ahead and put this change in a separate commit.

I also bumped the version and added `CHANGELOG.md`, taking style cues from your other gems (`pluck_map` in particular). Feel free to tweak or ask for changes on those if the style/wording isn't what you had in mind. 🙂 